### PR TITLE
[AssetMapper] Add integrity hash to modulepreload

### DIFF
--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -78,7 +78,7 @@ class ImportMapRenderer
                     $integrityMap[$path] = $integrity;
                 }
                 if ($preload) {
-                    $modulePreloads[] = $path;
+                    $modulePreloads[] = ['path' => $path, 'integrity' => $integrity];
                 }
             } elseif ($preload) {
                 $cssLinks[] = $path;
@@ -142,10 +142,13 @@ class ImportMapRenderer
                 HTML;
         }
 
-        foreach ($modulePreloads as $url) {
-            $url = $this->escapeAttributeValue($url);
+        foreach ($modulePreloads as $modulePreload) {
+            $url = $this->escapeAttributeValue($modulePreload['path']);
+            if ($integrity = $modulePreload['integrity']) {
+                $integrity = " integrity=\"$integrity\"";
+            }
 
-            $output .= "\n<link rel=\"modulepreload\" href=\"$url\">";
+            $output .= "\n<link rel=\"modulepreload\" href=\"$url\"$integrity>";
         }
 
         if (\count($entryPoint) > 0) {


### PR DESCRIPTION
Hi,

I just fixed the "preloads" added by importmap().

Without this fix, a browser show this message in Console warning:
>A preload for 'http://127.0.0.1:8000/assets/app-lFoIdGS.js' is found, but is not used due to an integrity mismatch.

That's because the integrity hash was not in the preload <link>

https://symfony.com/doc/current/frontend/asset_mapper.html#the-app-entrypoint-preloading